### PR TITLE
Support receiving extended packets from client

### DIFF
--- a/ultimaonline-net/macros/src/lib.rs
+++ b/ultimaonline-net/macros/src/lib.rs
@@ -40,9 +40,14 @@ pub fn packet(args: TokenStream, item: TokenStream) -> TokenStream {
 
     let fromdata_impl = content_from_packet(main_ident, &args);
 
-    let packet_id = match args {
-        PacketArgs::Standard(StandardPacket { id, .. }) => quote! {#id},
-        PacketArgs::Extended(_) => quote! {crate::packets::EXTENDED_PACKET_ID},
+    let (packet_id, extended_id) = match args {
+        PacketArgs::Standard(StandardPacket { id, .. }) => (quote! {#id}, quote! {None}),
+        PacketArgs::Extended(ExtendedPacket { id }) => (
+            quote! {crate::packets::EXTENDED_PACKET_ID},
+            quote! {
+                Some(#id)
+            },
+        ),
     };
 
     quote! {
@@ -51,6 +56,7 @@ pub fn packet(args: TokenStream, item: TokenStream) -> TokenStream {
 
         impl #main_ident {
             pub const PACKET_ID: u8 = #packet_id;
+            pub const EXTENDED_ID: Option<u16> = #extended_id;
         }
 
         #from_value

--- a/ultimaonline-net/macros/src/lib.rs
+++ b/ultimaonline-net/macros/src/lib.rs
@@ -1,7 +1,7 @@
 use darling::FromMeta;
 use proc_macro::{self, TokenStream};
 use quote::quote;
-use syn::{parse_macro_input, AttributeArgs, ItemStruct};
+use syn::{parse_macro_input, *};
 
 #[derive(Debug, FromMeta)]
 struct PacketArgs {
@@ -25,26 +25,12 @@ pub fn packet(args: TokenStream, item: TokenStream) -> TokenStream {
     let main_struct = parse_macro_input!(item as ItemStruct);
     let main_ident = &main_struct.ident;
 
-    // If this packet has a variable size, generate code to
-    // calculate the size and include it when serializing
-    let (size_field, size_calc, size_check) = match args.var_size {
-        true => (
-            quote! {size: Some(size as u16),},
-            quote! {
-                let size = crate::ser::to_size(val).expect("Could not serialize packet for size");
-                let size = ::core::mem::size_of::<u8>() + // packet id
-                           ::core::mem::size_of::<u16>() + // packet size
-                           size;
-            },
-            quote! {
-                // TODO: Actually check this length value
-                let _ = reader.read_u16::<BigEndian>().map_err(Error::io)?;
-            },
-        ),
-        false => (quote! {size: None,}, quote! {}, quote! {}),
-    };
+    let from_value = packet_from_content(&parse_quote! {#main_ident}, packet_id, args.var_size);
+    let from_ref = packet_from_content(&parse_quote! {&'a #main_ident}, packet_id, args.var_size);
 
-    let output = quote! {
+    let fromdata_impl = content_from_packet(main_ident, packet_id, args.var_size);
+
+    quote! {
         #[derive(::serde::Serialize, ::serde::Deserialize)]
         #main_struct
 
@@ -52,27 +38,80 @@ pub fn packet(args: TokenStream, item: TokenStream) -> TokenStream {
             pub const PACKET_ID: u8 = #packet_id;
         }
 
-        impl<'a> ::std::convert::From<&'a #main_ident> for crate::packets::Packet<&'a #main_ident> {
-            fn from(val: &'a #main_ident) -> Self {
+        #from_value
+
+        #from_ref
+
+        #fromdata_impl
+    }
+    .into()
+}
+
+fn packet_from_content(content_type: &Type, id: u8, var_size: bool) -> proc_macro2::TokenStream {
+    let (impl_param, to_size_param) = match content_type {
+        Type::Reference(r) => (
+            match &r.lifetime {
+                Some(l) => quote! {<#l>},
+                None => quote! {},
+            },
+            quote! {val},
+        ),
+        _ => (quote! {}, quote! {&val}),
+    };
+
+    // If this packet has a variable size, generate code to
+    // calculate the size and include it when serializing
+    let (size_calc, size_field) = if var_size {
+        (
+            quote! {
+                let size = crate::ser::to_size(#to_size_param).expect("Could not serialize packet for size");
+                let size = ::core::mem::size_of::<u8>() + // packet id
+                            ::core::mem::size_of::<u16>() + // packet size
+                            size;
+            },
+            quote! {
+               size: Some(size as u16)
+            },
+        )
+    } else {
+        (quote! {}, quote! {size: None})
+    };
+
+    quote! {
+        impl#impl_param ::std::convert::From<#content_type> for crate::packets::Packet<#content_type> {
+            fn from(val: #content_type) -> Self {
                 #size_calc
 
                 crate::packets::Packet {
-                    id: #packet_id,
-                    #size_field
+                    id: #id,
+                    #size_field,
                     contents: val,
                 }
             }
         }
+    }
+}
 
-        impl crate::packets::FromPacketData for #main_ident {
+fn content_from_packet(name: &syn::Ident, id: u8, var_size: bool) -> proc_macro2::TokenStream {
+    let size_check = if var_size {
+        quote! {
+            // TODO: Actually check this length value
+            let _ = reader.read_u16::<BigEndian>().map_err(Error::io)?;
+        }
+    } else {
+        quote! {}
+    };
+
+    quote! {
+        impl crate::packets::FromPacketData for #name {
             fn from_packet_data<R: ::std::io::Read>(reader: &mut R) -> crate::error::Result<Self> {
                 use ::byteorder::{ReadBytesExt, BigEndian};
                 use crate::error::Error;
 
                 // Parse out the packet header
                 let packet_id = reader.read_u8().map_err(Error::io)?;
-                if(packet_id != #packet_id) {
-                    return Err(Error::data(format!("Packet ID {} did not match expected {}", packet_id, #packet_id)));
+                if(packet_id != #id) {
+                    return Err(Error::data(format!("Packet ID {:#0X} did not match expected {:#0X}", packet_id, #id)));
                 }
 
                 #size_check
@@ -80,7 +119,5 @@ pub fn packet(args: TokenStream, item: TokenStream) -> TokenStream {
                 crate::de::from_reader(reader)
             }
         }
-    };
-
-    output.into()
+    }
 }

--- a/ultimaonline-net/src/packets.rs
+++ b/ultimaonline-net/src/packets.rs
@@ -8,6 +8,8 @@ pub mod login;
 pub mod mobile;
 pub mod world;
 
+pub const EXTENDED_PACKET_ID: u8 = 0xBF;
+
 #[derive(Serialize)]
 pub struct Packet<T> {
     id: u8,

--- a/ultimaonline-net/src/packets/char_login.rs
+++ b/ultimaonline-net/src/packets/char_login.rs
@@ -14,7 +14,7 @@ pub enum BodyType {
     Equipment,
 }
 
-#[packet(id = 0x1B)]
+#[packet(standard(id = 0x1B))]
 pub struct LoginConfirmation {
     pub serial: Serial,
 
@@ -31,7 +31,7 @@ pub struct LoginConfirmation {
     pub unknown_15: [u8; 14], // All zero
 }
 
-#[packet(id = 0x55)]
+#[packet(standard(id = 0x55))]
 pub struct LoginComplete;
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -43,7 +43,7 @@ pub struct Attribute {
 pub type Stat = u16;
 pub type Resistance = u16;
 
-#[packet(id = 0x11, var_size = true)]
+#[packet(standard(id = 0x11, var_size = true))]
 pub struct CharStatus {
     pub serial: Serial,
     pub name: Name,

--- a/ultimaonline-net/src/packets/char_select.rs
+++ b/ultimaonline-net/src/packets/char_select.rs
@@ -3,19 +3,19 @@ use macros::packet;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[packet(id = 0x91)]
+#[packet(standard(id = 0x91))]
 pub struct GameLogin {
     pub seed: u32,
     pub username: FixedStr<30>,
     pub password: FixedStr<30>,
 }
 
-#[packet(id = 0xB9)]
+#[packet(standard(id = 0xB9))]
 pub struct Features {
     pub flags: u32,
 }
 
-#[packet(id = 0xA9, var_size = true)]
+#[packet(standard(id = 0xA9, var_size = true))]
 pub struct CharList {
     pub chars: List<CharInfo, 8>,
     pub cities: List<CityInfo, 8>,
@@ -169,7 +169,7 @@ pub struct Character {
     appearance: CharAppearance,
 }
 
-#[packet(id = 0xF8)]
+#[packet(standard(id = 0xF8))]
 pub struct CreateCharacter {
     unknown_00: u32, // 0xEDEDEDED
     unknown_04: u16, // 0xFFFF
@@ -196,12 +196,12 @@ pub struct CreateCharacter {
     pants_hue: Hue,
 }
 
-#[packet(id = 0xBD)]
+#[packet(standard(id = 0xBD))]
 pub struct VersionReq {
     pub unknown_00: u16, // 0x0003
 }
 
-#[packet(id = 0xBD, var_size = true)]
+#[packet(standard(id = 0xBD, var_size = true))]
 #[derive(Debug, PartialEq)]
 pub struct VersionResp {
     pub version: String,

--- a/ultimaonline-net/src/packets/login.rs
+++ b/ultimaonline-net/src/packets/login.rs
@@ -22,13 +22,13 @@ impl std::fmt::Display for ClientVersion {
     }
 }
 
-#[packet(id = 0xEF)]
+#[packet(standard(id = 0xEF))]
 pub struct ClientHello {
     pub seed: u32,
     pub version: ClientVersion,
 }
 
-#[packet(id = 0x80)]
+#[packet(standard(id = 0x80))]
 pub struct AccountLogin {
     pub username: FixedStr<30>,
     pub password: FixedStr<30>,
@@ -47,7 +47,7 @@ pub enum LoginRejectionReason {
     BadComm = 255,
 }
 
-#[packet(id = 0x82)]
+#[packet(standard(id = 0x82))]
 #[derive(Debug, PartialEq)]
 pub struct LoginRejection {
     pub reason: LoginRejectionReason,
@@ -62,19 +62,19 @@ pub struct ServerInfo {
     pub ip_address: Ipv4Addr,
 }
 
-#[packet(id = 0xA8, var_size = true)]
+#[packet(standard(id = 0xA8, var_size = true))]
 #[derive(Debug, PartialEq)]
 pub struct ServerList {
     pub flags: u8,
     pub list: List<ServerInfo, 16>,
 }
 
-#[packet(id = 0xA0)]
+#[packet(standard(id = 0xA0))]
 pub struct ServerSelection {
     pub index: u16,
 }
 
-#[packet(id = 0x8C)]
+#[packet(standard(id = 0x8C))]
 #[derive(Debug, PartialEq)]
 pub struct GameServerHandoff {
     pub socket: SocketAddrV4,

--- a/ultimaonline-net/src/packets/map.rs
+++ b/ultimaonline-net/src/packets/map.rs
@@ -1,6 +1,6 @@
 use macros::packet;
 
-#[packet(id = 0xBF, var_size = true)]
+#[packet(standard(id = 0xBF, var_size = true))]
 pub struct MapChange {
     unknown_00: u16, // 0x0008
     map_id: u8,

--- a/ultimaonline-net/src/packets/mobile.rs
+++ b/ultimaonline-net/src/packets/mobile.rs
@@ -17,7 +17,7 @@ pub enum EntityFlags {
     Hidden = 0x80,
 }
 
-#[packet(id = 0x4E)]
+#[packet(standard(id = 0x4E))]
 pub struct MobLightLevel {
     pub serial: Serial,
     pub level: u8,
@@ -31,7 +31,7 @@ pub struct Item {
     pub hue: Hue,
 }
 
-#[packet(id = 0x77)]
+#[packet(standard(id = 0x77))]
 pub struct State {
     pub serial: Serial,
     pub body: Graphic,
@@ -44,7 +44,7 @@ pub struct State {
     pub notoriety: Notoriety,
 }
 
-#[packet(id = 0x78, var_size = true)]
+#[packet(standard(id = 0x78, var_size = true))]
 pub struct Appearance {
     pub state: State,
     pub items: ListTerm<Item, 32>,

--- a/ultimaonline-net/src/packets/world.rs
+++ b/ultimaonline-net/src/packets/world.rs
@@ -1,6 +1,6 @@
 use macros::packet;
 
-#[packet(id = 0x4F)]
+#[packet(standard(id = 0x4F))]
 pub struct WorldLightLevel {
     pub level: u8,
 }


### PR DESCRIPTION
The UO network protocol has a concept of extended packets (as I'm calling them), which use a particular packet ID (0xBF) to indicate a variable-size packet with an additional 16-bit packet ID following the size field.

With this PR we can specify extended packets using the `packet` proc macro, and decode them if they're included in the `recv` packets list in a `codec` macro.

The `packet` macro implementation was also rewritten to be a lot cleaner.