### PR TITLE
Various early in-world packets from client

### DIFF
--- a/ultimaonline-net/src/packets.rs
+++ b/ultimaonline-net/src/packets.rs
@@ -2,10 +2,15 @@ use crate::error::Result;
 use serde::Serialize;
 use std::io::{Read, Write};
 
+pub mod action;
 pub mod char_login;
 pub mod char_select;
+pub mod chat;
+pub mod client_info;
+pub mod housing;
 pub mod login;
 pub mod mobile;
+pub mod network;
 pub mod world;
 
 pub const EXTENDED_PACKET_ID: u8 = 0xBF;

--- a/ultimaonline-net/src/packets/action.rs
+++ b/ultimaonline-net/src/packets/action.rs
@@ -1,0 +1,12 @@
+use crate::types::Serial;
+use macros::packet;
+
+#[packet(standard(id = 0x06))]
+pub struct ClickUse {
+    serial: Serial,
+}
+
+#[packet(standard(id = 0x09))]
+pub struct ClickLook {
+    serial: Serial,
+}

--- a/ultimaonline-net/src/packets/chat.rs
+++ b/ultimaonline-net/src/packets/chat.rs
@@ -1,0 +1,9 @@
+use macros::packet;
+
+// TODO: Figure out if this will have actual content
+// ModernUO implementation says it doesn't.
+#[packet(standard(id = 0xB5))]
+pub struct OpenWindow {
+    pub unused_00: [u8; 0x20], // All zeros?
+    pub unused_20: [u8; 0x1F], // All zeros?
+}

--- a/ultimaonline-net/src/packets/client_info.rs
+++ b/ultimaonline-net/src/packets/client_info.rs
@@ -1,0 +1,104 @@
+use macros::packet;
+
+use crate::types::FixedStr;
+
+#[packet(extended(id = 0x05))]
+#[derive(Debug, PartialEq)]
+pub struct WindowSize {
+    pub width: u32,
+    pub height: u32,
+}
+
+#[packet(extended(id = 0x0B))]
+#[derive(Debug, PartialEq)]
+pub struct Language {
+    pub lang: FixedStr<4>,
+}
+
+// TODO: Investigate whether ClassicUO is
+// calculating the flags incorrectly.
+// ModernUO ignores this entirely.
+#[packet(extended(id = 0x0F))]
+pub struct Flags {
+    pub unknown_00: u8, // Always 0x0A
+    pub flags: u32,     // Always 0xFFFFFFFF
+}
+
+#[packet(standard(id = 0xC8))]
+pub struct ViewRange {
+    pub range: u8,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::packets::{FromPacketData, Packet};
+    use crate::ser::to_writer;
+    mod window_size {
+        use super::*;
+
+        #[test]
+        fn serialize() {
+            let expected_bytes = [
+                0xBFu8, 0x00, 0x0D, 0x00, 0x05, 0x00, 0x32, 0x47, 0xD5, 0x34, 0x93, 0x47, 0xDF,
+            ];
+
+            let mut packet = Vec::<u8>::new();
+            to_writer(
+                &mut packet,
+                &Packet::<_>::from(&WindowSize {
+                    width: 3295189,
+                    height: 882067423,
+                }),
+            )
+            .expect("Failed to write packet");
+
+            assert_eq!(packet.as_slice(), expected_bytes);
+        }
+
+        #[test]
+        fn deserialize() {
+            let window_size = WindowSize {
+                width: 345_729_057,
+                height: 3_820_817_358,
+            };
+
+            let mut input: &[u8] = &[
+                0xBFu8, 0x00, 0x0D, 0x00, 0x05, 0x14, 0x9b, 0x68, 0x21, 0xE3, 0xBD, 0x0B, 0xCE,
+            ];
+
+            let parsed = WindowSize::from_packet_data(&mut input).expect("Failed to parse packet");
+
+            assert_eq!(parsed, window_size);
+        }
+    }
+
+    mod language {
+        use super::*;
+
+        #[test]
+        fn serialize() {
+            let expected_bytes = [0xBFu8, 0x00, 0x09, 0x00, 0x0B, 0x45, 0x4E, 0x55, 0x00];
+
+            let mut packet = Vec::<u8>::new();
+            to_writer(
+                &mut packet,
+                &Packet::<_>::from(&Language { lang: "ENU".into() }),
+            )
+            .expect("Failed to write packet");
+
+            assert_eq!(packet.as_slice(), expected_bytes);
+        }
+
+        #[test]
+        fn deserialize() {
+            let language = Language { lang: "RUS".into() };
+
+            let mut input: &[u8] = &[0xBFu8, 0x00, 0x09, 0x00, 0x0B, 0x52, 0x55, 0x53, 0x00];
+
+            let parsed = Language::from_packet_data(&mut input).expect("Failed to parse packet");
+
+            assert_eq!(parsed, language);
+        }
+    }
+}

--- a/ultimaonline-net/src/packets/housing.rs
+++ b/ultimaonline-net/src/packets/housing.rs
@@ -1,0 +1,6 @@
+use macros::packet;
+
+#[packet(standard(id = 0xFB))]
+pub struct ShowPublicContent {
+    show: bool,
+}

--- a/ultimaonline-net/src/packets/mobile.rs
+++ b/ultimaonline-net/src/packets/mobile.rs
@@ -49,3 +49,17 @@ pub struct Appearance {
     pub state: State,
     pub items: ListTerm<Item, 32>,
 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum QueryKind {
+    Status = 0x4,
+    Skills = 0x5,
+}
+
+#[packet(standard(id = 0x34))]
+pub struct Query {
+    pub unused: u32, // 0xEDEDEDED
+    pub kind: QueryKind,
+    pub serial: Serial,
+}

--- a/ultimaonline-net/src/packets/network.rs
+++ b/ultimaonline-net/src/packets/network.rs
@@ -1,0 +1,11 @@
+use macros::packet;
+
+#[packet(standard(id = 0x73))]
+pub struct PingReq {
+    pub val: u8,
+}
+
+#[packet(standard(id = 0x73))]
+pub struct PingAck {
+    pub val: u8,
+}

--- a/uoverse-server/src/bin/game.rs
+++ b/uoverse-server/src/bin/game.rs
@@ -367,12 +367,18 @@ async fn char_login<Io: AsyncIo>(mut state: CharSelect<Io>) -> Result<InWorld<Io
 }
 
 async fn in_world<Io: AsyncIo>(server: Arc<server::Server>, mut state: InWorld<Io>) -> Result<()> {
+    use codecs::InWorldFrameRecv;
+    use ultimaonline_net::packets::network::{PingAck, PingReq};
+
     let mut client = server.new_client()?;
 
     loop {
         tokio::select! {
             res = state.recv() => {
                 match res {
+                    Ok(Some(InWorldFrameRecv::PingReq(PingReq {val}))) => {
+                        state.send(&PingAck{val}).await?
+                    },
                     Ok(Some(packet)) => client.send(packet)?,
                     Ok(None) => {
                         println!("Client connection closed.");

--- a/uoverse-server/src/game/client.rs
+++ b/uoverse-server/src/game/client.rs
@@ -281,9 +281,22 @@ pub mod codecs {
             mobile::Appearance,
             mobile::MobLightLevel,
             mobile::State,
+            network::PingAck,
             world::WorldLightLevel,
         ],
-        recv []
+        recv [
+            action::ClickUse,
+            action::ClickLook,
+            char_select::VersionResp,
+            chat::OpenWindow,
+            client_info::Flags,
+            client_info::Language,
+            client_info::WindowSize,
+            client_info::ViewRange,
+            housing::ShowPublicContent,
+            mobile::Query,
+            network::PingReq
+        ]
     }
 }
 


### PR DESCRIPTION
These were observed being sent from the ClassicUO client when it
connected to the server.

In order to prevent the server from disconnecting the client, we need to
handle every kind of packet we receive. Since these are sent
automatically upon entering the world, we at least need to accept them
otherwise the client will immediately disconnect.