### PR TITLE
Test mobile moves back and forth

### DIFF
--- a/uoverse-server/src/game/server.rs
+++ b/uoverse-server/src/game/server.rs
@@ -36,10 +36,31 @@ impl Server {
     }
 
     pub async fn run_loop(&self) -> Result<()> {
+        use ultimaonline_net::{packets::mobile, types};
+
         let mut frame = 0;
         while !self.shutdown.load(Ordering::Relaxed) {
             frame += 1;
             println!("Frame: {}", frame);
+            {
+                let mut world = self
+                    .world
+                    .lock()
+                    .map_err(|_| Error::Message("Unable to lock world".to_string()))?;
+                if (frame / 10) % 2 == 0 {
+                    world.mob_x += 1;
+                } else {
+                    world.mob_x -= 1;
+                }
+
+                if frame % 10 == 0 {
+                    world.mob_dir = match world.mob_dir {
+                        Direction::East => Direction::West,
+                        Direction::West => Direction::East,
+                        _ => Direction::East,
+                    };
+                }
+            }
 
             tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         }

--- a/uoverse-server/src/game/server.rs
+++ b/uoverse-server/src/game/server.rs
@@ -60,6 +60,32 @@ impl Server {
                         _ => Direction::East,
                     };
                 }
+
+                let mut clients = self
+                    .clients
+                    .lock()
+                    .map_err(|_| Error::Message("Unable to lock clients vec".to_string()))?;
+
+                for (i, client) in clients.iter_mut().enumerate() {
+                    if client.sender.is_closed() {
+                        continue;
+                    }
+
+                    client.send(
+                        mobile::State {
+                            serial: 55858,
+                            body: 401,
+                            x: world.mob_x,
+                            y: 2625,
+                            z: 0,
+                            direction: world.mob_dir,
+                            hue: 1003,
+                            flags: mobile::EntityFlags::None,
+                            notoriety: types::Notoriety::Ally,
+                        }
+                        .into(),
+                    )?;
+                }
             }
 
             tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;

--- a/uoverse-server/src/game/server.rs
+++ b/uoverse-server/src/game/server.rs
@@ -66,8 +66,10 @@ impl Server {
                     .lock()
                     .map_err(|_| Error::Message("Unable to lock clients vec".to_string()))?;
 
+                let mut closed_clients: Vec<usize> = vec![];
                 for (i, client) in clients.iter_mut().enumerate() {
                     if client.sender.is_closed() {
+                        closed_clients.push(i);
                         continue;
                     }
 
@@ -85,6 +87,12 @@ impl Server {
                         }
                         .into(),
                     )?;
+                }
+
+                closed_clients.sort();
+                closed_clients.reverse();
+                for i in closed_clients {
+                    clients.remove(i);
                 }
             }
 


### PR DESCRIPTION
This is implemented with shared world state, so that all connected clients see the same movement of the test mobile.

This also correctly detects and removes clients that have disconnected, so that the server continues running after a client leaves.