### PR TITLE
Rewrite UO protocol list types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
+name = "paste"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +551,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "nom",
+ "paste",
  "serde",
  "serde_repr",
  "ultimaonline-net-macros",

--- a/ultimaonline-net/Cargo.toml
+++ b/ultimaonline-net/Cargo.toml
@@ -11,3 +11,4 @@ nom = "6.0.1"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_repr = "0.1.6"
 ultimaonline-net-macros = { path = "macros" }
+paste = "1.0.7"

--- a/ultimaonline-net/macros/src/lib.rs
+++ b/ultimaonline-net/macros/src/lib.rs
@@ -135,11 +135,10 @@ fn content_from_packet(name: &syn::Ident, args: &PacketArgs) -> proc_macro2::Tok
 
     let size_check = match args {
         Fixed { .. } => quote! {
-            let _size = #name::SIZE.unwrap();
+            let size = #name::SIZE.unwrap();
         },
         _ => quote! {
-            // TODO: Actually check this length value
-            let _size = reader.read_u16::<BigEndian>().map_err(Error::io)? as usize
+            let size = reader.read_u16::<BigEndian>().map_err(Error::io)? as usize
                 - 1  // Packet ID
                 - 2; // Size field
         },
@@ -153,7 +152,7 @@ fn content_from_packet(name: &syn::Ident, args: &PacketArgs) -> proc_macro2::Tok
                 return Err(Error::data(format!("Packet extended ID {:#0X} did not match expected {:#0X}", extended_id, #id)));
             }
 
-            let _size = _size - 2; // Extended ID
+            let size = size - 2; // Extended ID
         },
         _ => quote! {},
     };
@@ -179,7 +178,7 @@ fn content_from_packet(name: &syn::Ident, args: &PacketArgs) -> proc_macro2::Tok
 
                 #read_extended_id
 
-                crate::de::from_reader(reader)
+                crate::de::from_reader(reader, size)
             }
         }
     }

--- a/ultimaonline-net/macros/src/lib.rs
+++ b/ultimaonline-net/macros/src/lib.rs
@@ -4,25 +4,16 @@ use quote::quote;
 use syn::{parse_macro_input, *};
 
 #[derive(Debug, FromMeta)]
-struct StandardPacket {
-    id: u8,
-    #[darling(default)]
-    var_size: bool,
-}
-
-#[derive(Debug, FromMeta)]
-struct ExtendedPacket {
-    id: u16,
-}
-
-#[derive(Debug, FromMeta)]
 enum PacketArgs {
-    Standard(StandardPacket),
-    Extended(ExtendedPacket),
+    Fixed { id: u8, size: usize },
+    Var { id: u8 },
+    Extended { id: u16 },
 }
 
 #[proc_macro_attribute]
 pub fn packet(args: TokenStream, item: TokenStream) -> TokenStream {
+    use PacketArgs::*;
+
     let parsed_args = parse_macro_input!(args as AttributeArgs);
 
     let args = match PacketArgs::from_list(&parsed_args) {
@@ -41,13 +32,18 @@ pub fn packet(args: TokenStream, item: TokenStream) -> TokenStream {
     let fromdata_impl = content_from_packet(main_ident, &args);
 
     let (packet_id, extended_id) = match args {
-        PacketArgs::Standard(StandardPacket { id, .. }) => (quote! {#id}, quote! {None}),
-        PacketArgs::Extended(ExtendedPacket { id }) => (
+        Fixed { id, .. } | Var { id } => (quote! {#id}, quote! {None}),
+        Extended { id } => (
             quote! {crate::packets::EXTENDED_PACKET_ID},
             quote! {
                 Some(#id)
             },
         ),
+    };
+
+    let packet_size = match args {
+        Fixed { size, .. } => quote!(Some(#size)),
+        _ => quote!(None),
     };
 
     quote! {
@@ -57,6 +53,7 @@ pub fn packet(args: TokenStream, item: TokenStream) -> TokenStream {
         impl #main_ident {
             pub const PACKET_ID: u8 = #packet_id;
             pub const EXTENDED_ID: Option<u16> = #extended_id;
+            pub const SIZE: Option<usize> = #packet_size;
         }
 
         #from_value
@@ -69,6 +66,8 @@ pub fn packet(args: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn packet_from_content(content_type: &Type, args: &PacketArgs) -> proc_macro2::TokenStream {
+    use PacketArgs::*;
+
     let (impl_param, to_size_param) = match content_type {
         Type::Reference(r) => (
             match &r.lifetime {
@@ -83,9 +82,7 @@ fn packet_from_content(content_type: &Type, args: &PacketArgs) -> proc_macro2::T
     // If this packet has a variable size, generate code to
     // calculate the size and include it when serializing
     let (size_calc, size_field) = match args {
-        PacketArgs::Standard(StandardPacket {
-            var_size: false, ..
-        }) => (quote! {}, quote! {size: None}),
+        Fixed { .. } => (quote! {}, quote! {size: None}),
         _ => (
             quote! {
                 let size = crate::ser::to_size(#to_size_param).expect("Could not serialize packet for size");
@@ -101,7 +98,7 @@ fn packet_from_content(content_type: &Type, args: &PacketArgs) -> proc_macro2::T
 
     let from_type = content_type;
     let (size_calc, content_type, content_val) = match args {
-        PacketArgs::Extended(ExtendedPacket { id }) => (
+        Extended { id } => (
             quote! {
                 #size_calc
                 let size = ::core::mem::size_of::<u16>() + // extended id
@@ -114,8 +111,8 @@ fn packet_from_content(content_type: &Type, args: &PacketArgs) -> proc_macro2::T
     };
 
     let id = match args {
-        PacketArgs::Standard(StandardPacket { id, .. }) => quote! {#id},
-        PacketArgs::Extended(_) => quote! {crate::packets::EXTENDED_PACKET_ID},
+        Fixed { id, .. } | Var { id } => quote! {#id},
+        Extended { .. } => quote! {crate::packets::EXTENDED_PACKET_ID},
     };
 
     quote! {
@@ -134,30 +131,36 @@ fn packet_from_content(content_type: &Type, args: &PacketArgs) -> proc_macro2::T
 }
 
 fn content_from_packet(name: &syn::Ident, args: &PacketArgs) -> proc_macro2::TokenStream {
+    use PacketArgs::*;
+
     let size_check = match args {
-        PacketArgs::Standard(StandardPacket {
-            var_size: false, ..
-        }) => quote! {},
+        Fixed { .. } => quote! {
+            let _size = #name::SIZE.unwrap();
+        },
         _ => quote! {
             // TODO: Actually check this length value
-            let _ = reader.read_u16::<BigEndian>().map_err(Error::io)?;
+            let _size = reader.read_u16::<BigEndian>().map_err(Error::io)? as usize
+                - 1  // Packet ID
+                - 2; // Size field
         },
     };
 
     let read_extended_id = match args {
-        PacketArgs::Extended(ExtendedPacket { id }) => quote! {
+        Extended { id } => quote! {
             // Parse out the extended id
             let extended_id = reader.read_u16::<BigEndian>().map_err(Error::io)?;
             if(extended_id != #id) {
                 return Err(Error::data(format!("Packet extended ID {:#0X} did not match expected {:#0X}", extended_id, #id)));
             }
+
+            let _size = _size - 2; // Extended ID
         },
         _ => quote! {},
     };
 
     let id = match args {
-        PacketArgs::Standard(StandardPacket { id, .. }) => quote! {#id},
-        PacketArgs::Extended(_) => quote! {crate::packets::EXTENDED_PACKET_ID},
+        Fixed { id, .. } | Var { id } => quote! {#id},
+        Extended { .. } => quote! {crate::packets::EXTENDED_PACKET_ID},
     };
 
     quote! {

--- a/ultimaonline-net/macros/src/lib.rs
+++ b/ultimaonline-net/macros/src/lib.rs
@@ -51,7 +51,7 @@ pub fn packet(args: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     quote! {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[derive(Clone, Debug, PartialEq, ::serde::Serialize, ::serde::Deserialize)]
         #main_struct
 
         impl #main_ident {

--- a/ultimaonline-net/macros/src/lib.rs
+++ b/ultimaonline-net/macros/src/lib.rs
@@ -162,7 +162,7 @@ fn content_from_packet(name: &syn::Ident, args: &PacketArgs) -> proc_macro2::Tok
 
     quote! {
         impl crate::packets::FromPacketData for #name {
-            fn from_packet_data<R: ::std::io::Read>(reader: &mut R) -> crate::error::Result<Self> {
+            fn from_packet_data<R: ::std::io::BufRead>(reader: &mut R) -> crate::error::Result<Self> {
                 use ::byteorder::{ReadBytesExt, BigEndian};
                 use crate::error::Error;
 

--- a/ultimaonline-net/src/de.rs
+++ b/ultimaonline-net/src/de.rs
@@ -363,6 +363,40 @@ where
         visitor.visit_seq(Access { deserializer: self })
     }
 
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        // HACK: We only support enums for TermList elements
+        visitor.visit_enum(TerminatorEnum { deserializer: self })
+    }
+
     // Unimplemented parts of the Serde data model
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -386,27 +420,6 @@ where
         unimplemented!();
     }
 
-    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_unit()
-    }
-
-    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_unit()
-    }
-
-    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_newtype_struct(self)
-    }
-
     fn deserialize_tuple_struct<V>(
         self,
         _name: &'static str,
@@ -424,19 +437,6 @@ where
         V: Visitor<'de>,
     {
         unimplemented!();
-    }
-
-    fn deserialize_enum<V>(
-        self,
-        _name: &'static str,
-        _variants: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        // HACK: We only support enums for TermList elements
-        visitor.visit_enum(TerminatorEnum { deserializer: self })
     }
 
     fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value>

--- a/ultimaonline-net/src/de.rs
+++ b/ultimaonline-net/src/de.rs
@@ -386,18 +386,18 @@ where
         unimplemented!();
     }
 
-    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unimplemented!();
+        visitor.visit_unit()
     }
 
-    fn deserialize_unit_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value>
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unimplemented!();
+        visitor.visit_unit()
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>

--- a/ultimaonline-net/src/de.rs
+++ b/ultimaonline-net/src/de.rs
@@ -1,18 +1,21 @@
 use crate::error::{Error, Result};
 use byteorder::{BigEndian, ReadBytesExt};
-use serde::{de, de::Visitor, Deserialize};
+use serde::{
+    de::{self, Visitor},
+    Deserialize,
+};
 use std::{io, str};
 
 pub struct Deserializer<'a, R>
 where
-    R: io::Read,
+    R: io::BufRead,
 {
     reader: &'a mut R,
 }
 
 pub fn from_reader<'a, R, T>(reader: &'a mut R) -> Result<T>
 where
-    R: io::Read,
+    R: io::BufRead,
     T: Deserialize<'a>,
 {
     let mut deserializer = Deserializer { reader };
@@ -31,7 +34,7 @@ macro_rules! impl_read_literal {
 
 impl<R> Deserializer<'_, R>
 where
-    R: io::Read,
+    R: io::BufRead,
 {
     impl_read_literal!(read_u16: u16 = read_u16());
     impl_read_literal!(read_i16: i16 = read_i16());
@@ -47,7 +50,7 @@ where
 
 impl<'de, 'a, R> de::Deserializer<'de> for &'a mut Deserializer<'de, R>
 where
-    R: io::Read,
+    R: io::BufRead,
 {
     type Error = Error;
 
@@ -197,12 +200,12 @@ where
         V: Visitor<'de>,
     {
         // Adapted from serde_bincode
-        struct Access<'de, 'a, R: io::Read> {
+        struct Access<'de, 'a, R: io::BufRead> {
             deserializer: &'a mut Deserializer<'de, R>,
             len: usize,
         }
 
-        impl<'de, 'a, R: io::Read> de::SeqAccess<'de> for Access<'de, 'a, R> {
+        impl<'de, 'a, R: io::BufRead> de::SeqAccess<'de> for Access<'de, 'a, R> {
             type Error = Error;
 
             fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>

--- a/ultimaonline-net/src/de.rs
+++ b/ultimaonline-net/src/de.rs
@@ -400,11 +400,11 @@ where
         unimplemented!();
     }
 
-    fn deserialize_newtype_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value>
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unimplemented!();
+        visitor.visit_newtype_struct(self)
     }
 
     fn deserialize_tuple_struct<V>(

--- a/ultimaonline-net/src/packets.rs
+++ b/ultimaonline-net/src/packets.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use serde::Serialize;
-use std::io::{Read, Write};
+use std::io::{BufRead, Write};
 
 pub mod action;
 pub mod char_login;
@@ -35,7 +35,7 @@ pub trait FromPacketData
 where
     Self: Sized,
 {
-    fn from_packet_data<R: Read>(reader: &mut R) -> Result<Self>;
+    fn from_packet_data<R: BufRead>(reader: &mut R) -> Result<Self>;
 }
 
 pub fn write_packet<T, W: Write>(content: T, dst: &mut W) -> Result<()>

--- a/ultimaonline-net/src/packets/action.rs
+++ b/ultimaonline-net/src/packets/action.rs
@@ -1,12 +1,12 @@
 use crate::types::Serial;
 use macros::packet;
 
-#[packet(standard(id = 0x06))]
+#[packet(fixed(id = 0x06, size = 4))]
 pub struct ClickUse {
     serial: Serial,
 }
 
-#[packet(standard(id = 0x09))]
+#[packet(fixed(id = 0x09, size = 4))]
 pub struct ClickLook {
     serial: Serial,
 }

--- a/ultimaonline-net/src/packets/char_login.rs
+++ b/ultimaonline-net/src/packets/char_login.rs
@@ -14,7 +14,7 @@ pub enum BodyType {
     Equipment,
 }
 
-#[packet(standard(id = 0x1B))]
+#[packet(fixed(id = 0x1B, size = 36))]
 pub struct LoginConfirmation {
     pub serial: Serial,
 
@@ -31,7 +31,7 @@ pub struct LoginConfirmation {
     pub unknown_15: [u8; 14], // All zero
 }
 
-#[packet(standard(id = 0x55))]
+#[packet(fixed(id = 0x55, size = 0))]
 pub struct LoginComplete;
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -43,7 +43,7 @@ pub struct Attribute {
 pub type Stat = u16;
 pub type Resistance = u16;
 
-#[packet(standard(id = 0x11, var_size = true))]
+#[packet(var(id = 0x11))]
 pub struct CharStatus {
     pub serial: Serial,
     pub name: Name,

--- a/ultimaonline-net/src/packets/char_select.rs
+++ b/ultimaonline-net/src/packets/char_select.rs
@@ -3,19 +3,19 @@ use macros::packet;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[packet(standard(id = 0x91))]
+#[packet(fixed(id = 0x91, size = 64))]
 pub struct GameLogin {
     pub seed: u32,
     pub username: FixedStr<30>,
     pub password: FixedStr<30>,
 }
 
-#[packet(standard(id = 0xB9))]
+#[packet(fixed(id = 0xB9, size = 4))]
 pub struct Features {
     pub flags: u32,
 }
 
-#[packet(standard(id = 0xA9, var_size = true))]
+#[packet(var(id = 0xA9))]
 pub struct CharList {
     pub chars: List<CharInfo, u8>,
     pub cities: List<CityInfo, u8>,
@@ -169,7 +169,7 @@ pub struct Character {
     appearance: CharAppearance,
 }
 
-#[packet(standard(id = 0xF8))]
+#[packet(fixed(id = 0xF8, size = 105))]
 pub struct CreateCharacter {
     unknown_00: u32, // 0xEDEDEDED
     unknown_04: u16, // 0xFFFF
@@ -196,12 +196,12 @@ pub struct CreateCharacter {
     pants_hue: Hue,
 }
 
-#[packet(standard(id = 0xBD))]
+#[packet(fixed(id = 0xBD, size = 2))]
 pub struct VersionReq {
     pub unknown_00: u16, // 0x0003
 }
 
-#[packet(standard(id = 0xBD, var_size = true))]
+#[packet(var(id = 0xBD))]
 pub struct VersionResp {
     pub version: String,
 }

--- a/ultimaonline-net/src/packets/char_select.rs
+++ b/ultimaonline-net/src/packets/char_select.rs
@@ -202,7 +202,6 @@ pub struct VersionReq {
 }
 
 #[packet(standard(id = 0xBD, var_size = true))]
-#[derive(Debug, PartialEq)]
 pub struct VersionResp {
     pub version: String,
 }

--- a/ultimaonline-net/src/packets/char_select.rs
+++ b/ultimaonline-net/src/packets/char_select.rs
@@ -17,8 +17,8 @@ pub struct Features {
 
 #[packet(standard(id = 0xA9, var_size = true))]
 pub struct CharList {
-    pub chars: List<CharInfo, 8>,
-    pub cities: List<CityInfo, 8>,
+    pub chars: List<CharInfo, u8>,
+    pub cities: List<CityInfo, u8>,
     pub flags: u32,
     pub unknown_var1: i32,
 }

--- a/ultimaonline-net/src/packets/chat.rs
+++ b/ultimaonline-net/src/packets/chat.rs
@@ -2,7 +2,7 @@ use macros::packet;
 
 // TODO: Figure out if this will have actual content
 // ModernUO implementation says it doesn't.
-#[packet(standard(id = 0xB5))]
+#[packet(fixed(id = 0xB5, size = 63))]
 pub struct OpenWindow {
     pub unused_00: [u8; 0x20], // All zeros?
     pub unused_20: [u8; 0x1F], // All zeros?

--- a/ultimaonline-net/src/packets/client_info.rs
+++ b/ultimaonline-net/src/packets/client_info.rs
@@ -3,14 +3,12 @@ use macros::packet;
 use crate::types::FixedStr;
 
 #[packet(extended(id = 0x05))]
-#[derive(Debug, PartialEq)]
 pub struct WindowSize {
     pub width: u32,
     pub height: u32,
 }
 
 #[packet(extended(id = 0x0B))]
-#[derive(Debug, PartialEq)]
 pub struct Language {
     pub lang: FixedStr<4>,
 }

--- a/ultimaonline-net/src/packets/client_info.rs
+++ b/ultimaonline-net/src/packets/client_info.rs
@@ -22,7 +22,7 @@ pub struct Flags {
     pub flags: u32,     // Always 0xFFFFFFFF
 }
 
-#[packet(standard(id = 0xC8))]
+#[packet(fixed(id = 0xC8, size = 1))]
 pub struct ViewRange {
     pub range: u8,
 }

--- a/ultimaonline-net/src/packets/housing.rs
+++ b/ultimaonline-net/src/packets/housing.rs
@@ -1,6 +1,6 @@
 use macros::packet;
 
-#[packet(standard(id = 0xFB))]
+#[packet(fixed(id = 0xFB, size = 1))]
 pub struct ShowPublicContent {
     show: bool,
 }

--- a/ultimaonline-net/src/packets/login.rs
+++ b/ultimaonline-net/src/packets/login.rs
@@ -66,7 +66,7 @@ pub struct ServerInfo {
 #[derive(Debug, PartialEq)]
 pub struct ServerList {
     pub flags: u8,
-    pub list: List<ServerInfo, 16>,
+    pub list: List<ServerInfo, u16>,
 }
 
 #[packet(standard(id = 0xA0))]

--- a/ultimaonline-net/src/packets/login.rs
+++ b/ultimaonline-net/src/packets/login.rs
@@ -22,13 +22,13 @@ impl std::fmt::Display for ClientVersion {
     }
 }
 
-#[packet(standard(id = 0xEF))]
+#[packet(fixed(id = 0xEF, size = 20))]
 pub struct ClientHello {
     pub seed: u32,
     pub version: ClientVersion,
 }
 
-#[packet(standard(id = 0x80))]
+#[packet(fixed(id = 0x80, size = 61))]
 pub struct AccountLogin {
     pub username: FixedStr<30>,
     pub password: FixedStr<30>,
@@ -47,7 +47,7 @@ pub enum LoginRejectionReason {
     BadComm = 255,
 }
 
-#[packet(standard(id = 0x82))]
+#[packet(fixed(id = 0x82, size = 1))]
 pub struct LoginRejection {
     pub reason: LoginRejectionReason,
 }
@@ -61,18 +61,18 @@ pub struct ServerInfo {
     pub ip_address: Ipv4Addr,
 }
 
-#[packet(standard(id = 0xA8, var_size = true))]
+#[packet(var(id = 0xA8))]
 pub struct ServerList {
     pub flags: u8,
     pub list: List<ServerInfo, u16>,
 }
 
-#[packet(standard(id = 0xA0))]
+#[packet(fixed(id = 0xA0, size = 2))]
 pub struct ServerSelection {
     pub index: u16,
 }
 
-#[packet(standard(id = 0x8C))]
+#[packet(fixed(id = 0x8C, size = 10))]
 pub struct GameServerHandoff {
     pub socket: SocketAddrV4,
     pub ticket: u32,

--- a/ultimaonline-net/src/packets/login.rs
+++ b/ultimaonline-net/src/packets/login.rs
@@ -48,7 +48,6 @@ pub enum LoginRejectionReason {
 }
 
 #[packet(standard(id = 0x82))]
-#[derive(Debug, PartialEq)]
 pub struct LoginRejection {
     pub reason: LoginRejectionReason,
 }
@@ -63,7 +62,6 @@ pub struct ServerInfo {
 }
 
 #[packet(standard(id = 0xA8, var_size = true))]
-#[derive(Debug, PartialEq)]
 pub struct ServerList {
     pub flags: u8,
     pub list: List<ServerInfo, u16>,
@@ -75,7 +73,6 @@ pub struct ServerSelection {
 }
 
 #[packet(standard(id = 0x8C))]
-#[derive(Debug, PartialEq)]
 pub struct GameServerHandoff {
     pub socket: SocketAddrV4,
     pub ticket: u32,

--- a/ultimaonline-net/src/packets/map.rs
+++ b/ultimaonline-net/src/packets/map.rs
@@ -1,6 +1,6 @@
 use macros::packet;
 
-#[packet(standard(id = 0xBF, var_size = true))]
+#[packet(var(id = 0xBF))]
 pub struct MapChange {
     unknown_00: u16, // 0x0008
     map_id: u8,

--- a/ultimaonline-net/src/packets/mobile.rs
+++ b/ultimaonline-net/src/packets/mobile.rs
@@ -17,7 +17,7 @@ pub enum EntityFlags {
     Hidden = 0x80,
 }
 
-#[packet(standard(id = 0x4E))]
+#[packet(fixed(id = 0x4E, size = 5))]
 pub struct MobLightLevel {
     pub serial: Serial,
     pub level: u8,
@@ -31,7 +31,7 @@ pub struct Item {
     pub hue: Hue,
 }
 
-#[packet(standard(id = 0x77))]
+#[packet(fixed(id = 0x77, size = 16))]
 pub struct State {
     pub serial: Serial,
     pub body: Graphic,
@@ -44,7 +44,7 @@ pub struct State {
     pub notoriety: Notoriety,
 }
 
-#[packet(standard(id = 0x78, var_size = true))]
+#[packet(var(id = 0x78))]
 pub struct Appearance {
     pub state: State,
     pub items: ListTerm<Item, u32>,
@@ -57,7 +57,7 @@ pub enum QueryKind {
     Skills = 0x5,
 }
 
-#[packet(standard(id = 0x34))]
+#[packet(fixed(id = 0x34, size = 9))]
 pub struct Query {
     pub unused: u32, // 0xEDEDEDED
     pub kind: QueryKind,

--- a/ultimaonline-net/src/packets/mobile.rs
+++ b/ultimaonline-net/src/packets/mobile.rs
@@ -47,7 +47,7 @@ pub struct State {
 #[packet(standard(id = 0x78, var_size = true))]
 pub struct Appearance {
     pub state: State,
-    pub items: ListTerm<Item, 32>,
+    pub items: ListTerm<Item, u32>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize_repr, Deserialize_repr)]

--- a/ultimaonline-net/src/packets/mobile.rs
+++ b/ultimaonline-net/src/packets/mobile.rs
@@ -23,7 +23,7 @@ pub struct MobLightLevel {
     pub level: u8,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Item {
     pub serial: Serial,
     pub type_id: u16,
@@ -32,6 +32,7 @@ pub struct Item {
 }
 
 #[packet(standard(id = 0x77))]
+#[derive(Debug, PartialEq)]
 pub struct State {
     pub serial: Serial,
     pub body: Graphic,
@@ -45,6 +46,7 @@ pub struct State {
 }
 
 #[packet(standard(id = 0x78, var_size = true))]
+#[derive(Debug, PartialEq)]
 pub struct Appearance {
     pub state: State,
     pub items: ListTerm<Item, u32>,
@@ -62,4 +64,121 @@ pub struct Query {
     pub unused: u32, // 0xEDEDEDED
     pub kind: QueryKind,
     pub serial: Serial,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::packets::{FromPacketData, Packet};
+    use crate::ser::to_writer;
+    mod appearance {
+        use super::*;
+
+        fn appearance() -> Appearance {
+            Appearance {
+                state: State {
+                    serial: 0x12345678,
+                    body: 0xBEEF,
+                    x: 0xABCD,
+                    y: 0xACAB,
+                    z: 0x7F,
+                    direction: Direction::North,
+                    hue: 0xDEAD,
+                    flags: EntityFlags::Hidden,
+                    notoriety: Notoriety::Innocent,
+                },
+                items: vec![
+                    Item {
+                        serial: 0x40000001,
+                        type_id: 0x1A1A,
+                        layer: 0x1B,
+                        hue: 0x1C1C,
+                    },
+                    Item {
+                        serial: 0x40000002,
+                        type_id: 0x2A2A,
+                        layer: 0x2B,
+                        hue: 0x2C2C,
+                    },
+                    Item {
+                        serial: 0x40000003,
+                        type_id: 0x3A3A,
+                        layer: 0x3B,
+                        hue: 0x3C3C,
+                    },
+                    Item {
+                        serial: 0x40000004,
+                        type_id: 0x4A4A,
+                        layer: 0x4B,
+                        hue: 0x4C4C,
+                    },
+                    Item {
+                        serial: 0x40000005,
+                        type_id: 0x5A5A,
+                        layer: 0x5B,
+                        hue: 0x5C5C,
+                    },
+                    Item {
+                        serial: 0x40000006,
+                        type_id: 0x6A6A,
+                        layer: 0x6B,
+                        hue: 0x6C6C,
+                    },
+                    Item {
+                        serial: 0x40000007,
+                        type_id: 0x7A7A,
+                        layer: 0x7B,
+                        hue: 0x7C7C,
+                    },
+                    Item {
+                        serial: 0x40000008,
+                        type_id: 0x8A8A,
+                        layer: 0x8B,
+                        hue: 0x8C8C,
+                    },
+                ]
+                .into(),
+            }
+        }
+
+        #[test]
+        fn serialize() {
+            let expected_bytes = [
+                0x78u8, 0x00, 0x5F, 0x12, 0x34, 0x56, 0x78, 0xBE, 0xEF, 0xAB, 0xCD, 0xAC, 0xAB,
+                0x7F, 0x00, 0xDE, 0xAD, 0x80, 0x01, 0x40, 0x00, 0x00, 0x01, 0x1A, 0x1A, 0x1B, 0x1C,
+                0x1C, 0x40, 0x00, 0x00, 0x02, 0x2A, 0x2A, 0x2B, 0x2C, 0x2C, 0x40, 0x00, 0x00, 0x03,
+                0x3A, 0x3A, 0x3B, 0x3C, 0x3C, 0x40, 0x00, 0x00, 0x04, 0x4A, 0x4A, 0x4B, 0x4C, 0x4C,
+                0x40, 0x00, 0x00, 0x05, 0x5A, 0x5A, 0x5B, 0x5C, 0x5C, 0x40, 0x00, 0x00, 0x06, 0x6A,
+                0x6A, 0x6B, 0x6C, 0x6C, 0x40, 0x00, 0x00, 0x07, 0x7A, 0x7A, 0x7B, 0x7C, 0x7C, 0x40,
+                0x00, 0x00, 0x08, 0x8A, 0x8A, 0x8B, 0x8C, 0x8C, 0x00, 0x00, 0x00, 0x00,
+            ];
+
+            let mut packet = Vec::<u8>::new();
+            to_writer(&mut packet, &Packet::<_>::from(&appearance()))
+                .expect("Failed to write packet");
+
+            assert_eq!(packet.as_slice(), expected_bytes);
+        }
+
+        #[test]
+        fn deserialize() {
+            let appearance = appearance();
+
+            let mut input: &[u8] = &[
+                0x78u8, 0x00, 0x5F, 0x12, 0x34, 0x56, 0x78, 0xBE, 0xEF, 0xAB, 0xCD, 0xAC, 0xAB,
+                0x7F, 0x00, 0xDE, 0xAD, 0x80, 0x01, 0x40, 0x00, 0x00, 0x01, 0x1A, 0x1A, 0x1B, 0x1C,
+                0x1C, 0x40, 0x00, 0x00, 0x02, 0x2A, 0x2A, 0x2B, 0x2C, 0x2C, 0x40, 0x00, 0x00, 0x03,
+                0x3A, 0x3A, 0x3B, 0x3C, 0x3C, 0x40, 0x00, 0x00, 0x04, 0x4A, 0x4A, 0x4B, 0x4C, 0x4C,
+                0x40, 0x00, 0x00, 0x05, 0x5A, 0x5A, 0x5B, 0x5C, 0x5C, 0x40, 0x00, 0x00, 0x06, 0x6A,
+                0x6A, 0x6B, 0x6C, 0x6C, 0x40, 0x00, 0x00, 0x07, 0x7A, 0x7A, 0x7B, 0x7C, 0x7C, 0x40,
+                0x00, 0x00, 0x08, 0x8A, 0x8A, 0x8B, 0x8C, 0x8C, 0x00, 0x00, 0x00, 0x00,
+            ];
+
+            println!("Packet len: {:x}", input.len());
+
+            let parsed = Appearance::from_packet_data(&mut input).expect("Failed to parse packet");
+
+            assert_eq!(parsed, appearance);
+        }
+    }
 }

--- a/ultimaonline-net/src/packets/mobile.rs
+++ b/ultimaonline-net/src/packets/mobile.rs
@@ -23,7 +23,7 @@ pub struct MobLightLevel {
     pub level: u8,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Item {
     pub serial: Serial,
     pub type_id: u16,
@@ -32,7 +32,6 @@ pub struct Item {
 }
 
 #[packet(standard(id = 0x77))]
-#[derive(Debug, PartialEq)]
 pub struct State {
     pub serial: Serial,
     pub body: Graphic,
@@ -46,7 +45,6 @@ pub struct State {
 }
 
 #[packet(standard(id = 0x78, var_size = true))]
-#[derive(Debug, PartialEq)]
 pub struct Appearance {
     pub state: State,
     pub items: ListTerm<Item, u32>,

--- a/ultimaonline-net/src/packets/network.rs
+++ b/ultimaonline-net/src/packets/network.rs
@@ -1,11 +1,11 @@
 use macros::packet;
 
-#[packet(standard(id = 0x73))]
+#[packet(fixed(id = 0x73, size = 1))]
 pub struct PingReq {
     pub val: u8,
 }
 
-#[packet(standard(id = 0x73))]
+#[packet(fixed(id = 0x73, size = 1))]
 pub struct PingAck {
     pub val: u8,
 }

--- a/ultimaonline-net/src/packets/world.rs
+++ b/ultimaonline-net/src/packets/world.rs
@@ -1,6 +1,6 @@
 use macros::packet;
 
-#[packet(standard(id = 0x4F))]
+#[packet(fixed(id = 0x4F, size = 1))]
 pub struct WorldLightLevel {
     pub level: u8,
 }

--- a/ultimaonline-net/src/ser.rs
+++ b/ultimaonline-net/src/ser.rs
@@ -220,6 +220,19 @@ where
         Ok(())
     }
 
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        val: &T,
+    ) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        val.serialize(self)
+    }
+
     // Lots of stuff unimplemented as it's not needed
 
     fn serialize_unit(self) -> Result<()> {
@@ -231,19 +244,6 @@ where
     }
 
     fn serialize_newtype_struct<T>(self, _: &'static str, _: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        unimplemented!()
-    }
-
-    fn serialize_newtype_variant<T>(
-        self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
-        _: &T,
-    ) -> Result<()>
     where
         T: ?Sized + Serialize,
     {

--- a/ultimaonline-net/src/ser.rs
+++ b/ultimaonline-net/src/ser.rs
@@ -169,10 +169,9 @@ where
 
             if let Some(writer) = &mut self.writer {
                 writer.write_all(v.as_bytes()).map_err(Error::io)?;
-                self.end_null()
-            } else {
-                Ok(())
             }
+
+            self.end_null()
         } else {
             Err(Error::data("Unsupported string encoding"))
         }

--- a/ultimaonline-net/src/ser.rs
+++ b/ultimaonline-net/src/ser.rs
@@ -219,6 +219,17 @@ where
         Ok(())
     }
 
+    fn serialize_newtype_struct<T>(self, _name: &'static str, val: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        val.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<()> {
+        Ok(())
+    }
+
     fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
@@ -232,21 +243,10 @@ where
         val.serialize(self)
     }
 
-    // Lots of stuff unimplemented as it's not needed
-
-    fn serialize_unit(self) -> Result<()> {
-        Ok(())
-    }
+    // Unimplemented parts of the serde data model
 
     fn serialize_unit_variant(self, _: &'static str, _: u32, _: &'static str) -> Result<()> {
         unimplemented!()
-    }
-
-    fn serialize_newtype_struct<T>(self, _name: &'static str, val: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        val.serialize(self)
     }
 
     fn serialize_tuple_variant(

--- a/ultimaonline-net/src/ser.rs
+++ b/ultimaonline-net/src/ser.rs
@@ -242,11 +242,11 @@ where
         unimplemented!()
     }
 
-    fn serialize_newtype_struct<T>(self, _: &'static str, _: &T) -> Result<()>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, val: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        val.serialize(self)
     }
 
     fn serialize_tuple_variant(

--- a/ultimaonline-net/src/ser.rs
+++ b/ultimaonline-net/src/ser.rs
@@ -235,7 +235,7 @@ where
     // Lots of stuff unimplemented as it's not needed
 
     fn serialize_unit(self) -> Result<()> {
-        unimplemented!()
+        Ok(())
     }
 
     fn serialize_unit_variant(self, _: &'static str, _: u32, _: &'static str) -> Result<()> {

--- a/ultimaonline-net/src/types/list.rs
+++ b/ultimaonline-net/src/types/list.rs
@@ -348,3 +348,24 @@ where
         }
     }
 }
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ListNonTerm<T: Serialize>(Vec<T>);
+
+impl<T: Serialize> Default for ListNonTerm<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<T: Serialize> From<Vec<T>> for ListNonTerm<T> {
+    fn from(val: Vec<T>) -> Self {
+        Self(val)
+    }
+}
+
+impl<T: Serialize> From<ListNonTerm<T>> for Vec<T> {
+    fn from(val: ListNonTerm<T>) -> Self {
+        val.0
+    }
+}


### PR DESCRIPTION
This improves on the design of the list types in a few ways:
* Use a type parameter instead of a constant parameter with the number of bits. The valid types must implement a trait specific to the list type, and implementations for the set of valid unsigned integer types are included.
* Updates how the `ListTerm` type is serialized and deserialized so that deserialization actually works. This is unfortunately a very hacky design still, because the appropriate type in serde's data model (a sequence of an untagged enum with variants for value and terminator) really only works naturally for self-describing formats, which UO's network protocol is not.
  There may be some way to improve this so that it doesn't prevent us from supporting tagged enums, but for the moment this was the only thing I could get to work after trying many, many different implementation approaches.
* Adds the `ListNonTerm` type which is a list type that has no length or terminator sentinel. As a result it only really makes sense in "tail position" because it naturally provides/consumes all of the rest of the serialized data for whatever type it is contained within.

These improvements required several changes to the serde Serializer and Deserializer implementations as well as the packet macro (which has been rewritten to be a lot cleaner). We also now need to provide explicit sizes to every packet which has a fixed length. Overall, there are still a lot of work that can be done on the infrastructure code for the UO protocol.