### PR TITLE
Basic cleanup for errors and logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +234,12 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "lexical-core"
@@ -601,6 +617,7 @@ dependencies = [
  "bytes",
  "ctrlc",
  "erased-serde",
+ "eyre",
  "futures",
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +574,7 @@ dependencies = [
  "paste",
  "serde",
  "serde_repr",
+ "thiserror",
  "ultimaonline-net-macros",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "lexical-core"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -406,6 +430,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,10 +491,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+
+[[package]]
+name = "smallvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -505,6 +568,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -569,7 +641,19 @@ checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -579,6 +663,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+dependencies = [
+ "ansi_term",
+ "matchers",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -624,6 +738,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tracing",
+ "tracing-subscriber",
  "ultimaonline-net",
  "uoverse-server-macros",
 ]
@@ -636,6 +752,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/ultimaonline-net/Cargo.toml
+++ b/ultimaonline-net/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0.119", features = ["derive"] }
 serde_repr = "0.1.6"
 ultimaonline-net-macros = { path = "macros" }
 paste = "1.0.7"
+thiserror = "1.0"

--- a/ultimaonline-net/macros/src/lib.rs
+++ b/ultimaonline-net/macros/src/lib.rs
@@ -149,7 +149,7 @@ fn content_from_packet(name: &syn::Ident, args: &PacketArgs) -> proc_macro2::Tok
             // Parse out the extended id
             let extended_id = reader.read_u16::<BigEndian>()?;
             if(extended_id != #id) {
-                return Err(Error::data(format!("Packet extended ID {:#0X} did not match expected {:#0X}", extended_id, #id)));
+                return Err(Error::data(format!("packet extended id {:#0X} did not match expected {:#0X}", extended_id, #id)));
             }
 
             let size = size - 2; // Extended ID
@@ -171,7 +171,7 @@ fn content_from_packet(name: &syn::Ident, args: &PacketArgs) -> proc_macro2::Tok
                 // Parse out the packet header
                 let packet_id = reader.read_u8()?;
                 if(packet_id != #id) {
-                    return Err(Error::data(format!("Packet ID {:#0X} did not match expected {:#0X}", packet_id, #id)));
+                    return Err(Error::data(format!("packet id {:#0X} did not match expected {:#0X}", packet_id, #id)));
                 }
 
                 #size_check

--- a/ultimaonline-net/macros/src/lib.rs
+++ b/ultimaonline-net/macros/src/lib.rs
@@ -138,7 +138,7 @@ fn content_from_packet(name: &syn::Ident, args: &PacketArgs) -> proc_macro2::Tok
             let size = #name::SIZE.unwrap();
         },
         _ => quote! {
-            let size = reader.read_u16::<BigEndian>().map_err(Error::io)? as usize
+            let size = reader.read_u16::<BigEndian>()? as usize
                 - 1  // Packet ID
                 - 2; // Size field
         },
@@ -147,7 +147,7 @@ fn content_from_packet(name: &syn::Ident, args: &PacketArgs) -> proc_macro2::Tok
     let read_extended_id = match args {
         Extended { id } => quote! {
             // Parse out the extended id
-            let extended_id = reader.read_u16::<BigEndian>().map_err(Error::io)?;
+            let extended_id = reader.read_u16::<BigEndian>()?;
             if(extended_id != #id) {
                 return Err(Error::data(format!("Packet extended ID {:#0X} did not match expected {:#0X}", extended_id, #id)));
             }
@@ -169,7 +169,7 @@ fn content_from_packet(name: &syn::Ident, args: &PacketArgs) -> proc_macro2::Tok
                 use crate::error::Error;
 
                 // Parse out the packet header
-                let packet_id = reader.read_u8().map_err(Error::io)?;
+                let packet_id = reader.read_u8()?;
                 if(packet_id != #id) {
                     return Err(Error::data(format!("Packet ID {:#0X} did not match expected {:#0X}", packet_id, #id)));
                 }

--- a/ultimaonline-net/src/de.rs
+++ b/ultimaonline-net/src/de.rs
@@ -54,7 +54,7 @@ macro_rules! impl_read_literal {
                     })
                 }
             } else {
-                let val = self.reader.$read_func::<BigEndian>().map_err(Error::io)?;
+                let val = self.reader.$read_func::<BigEndian>()?;
                 self.track_read(::core::mem::size_of::<$ty>())?;
 
                 Ok(val)
@@ -77,10 +77,11 @@ where
     impl_read_literal!(read_f64: f64 = read_f64());
 
     fn insufficient_buffer<T>() -> Error {
-        Error::io(io::Error::new(
+        io::Error::new(
             io::ErrorKind::UnexpectedEof,
             format!("insufficient buffer for {}", std::any::type_name::<T>()),
-        ))
+        )
+        .into()
     }
 
     fn track_read(&mut self, amount: usize) -> Result<()> {
@@ -110,7 +111,7 @@ where
             }
             buf[0]
         } else {
-            let val = self.reader.read_u8().map_err(Error::io)?;
+            let val = self.reader.read_u8()?;
             self.track_read(core::mem::size_of::<bool>())?;
             val
         };
@@ -129,7 +130,7 @@ where
             }
             buf[0]
         } else {
-            let val = self.reader.read_u8().map_err(Error::io)?;
+            let val = self.reader.read_u8()?;
             self.track_read(core::mem::size_of::<u8>())?;
             val
         };
@@ -148,7 +149,7 @@ where
             }
             buf[0] as i8
         } else {
-            let val = self.reader.read_i8().map_err(Error::io)?;
+            let val = self.reader.read_i8()?;
             self.track_read(core::mem::size_of::<i8>())?;
             val
         };
@@ -237,7 +238,7 @@ where
         // TODO: Make a zero-copy version of this if possible
         let mut buffer = vec![];
         loop {
-            let byte = self.reader.read_u8().map_err(Error::io)?;
+            let byte = self.reader.read_u8()?;
             match byte {
                 0 => break,
                 n => buffer.push(n),
@@ -265,7 +266,7 @@ where
 
         let mut buffer = vec![];
         loop {
-            let byte = self.reader.read_u8().map_err(Error::io)?;
+            let byte = self.reader.read_u8()?;
             match byte {
                 0 => break,
                 n => buffer.push(n),

--- a/ultimaonline-net/src/de.rs
+++ b/ultimaonline-net/src/de.rs
@@ -30,9 +30,7 @@ where
 
     match deserializer.remaining {
         0 => Ok(t),
-        _ => Err(Error::data(
-            "deserializer had data remaining after deserializing value",
-        )),
+        _ => Err(Error::de("data remains after deserializing value")),
     }
 }
 
@@ -85,9 +83,10 @@ where
     }
 
     fn track_read(&mut self, amount: usize) -> Result<()> {
-        self.remaining = self.remaining.checked_sub(amount).ok_or(Error::data(
-            "deserializer read past end of serialized value",
-        ))?;
+        self.remaining = self
+            .remaining
+            .checked_sub(amount)
+            .ok_or(Error::de("read past end of serialized value"))?;
         Ok(())
     }
 }

--- a/ultimaonline-net/src/de.rs
+++ b/ultimaonline-net/src/de.rs
@@ -31,7 +31,7 @@ where
     match deserializer.remaining {
         0 => Ok(t),
         _ => Err(Error::data(
-            "Deserializer had data remaining after deserializing value",
+            "deserializer had data remaining after deserializing value",
         )),
     }
 }
@@ -86,7 +86,7 @@ where
 
     fn track_read(&mut self, amount: usize) -> Result<()> {
         self.remaining = self.remaining.checked_sub(amount).ok_or(Error::data(
-            "Deserializer read past end of serialized value",
+            "deserializer read past end of serialized value",
         ))?;
         Ok(())
     }
@@ -247,10 +247,11 @@ where
 
         self.track_read(buffer.len() + 1)?;
 
-        let s = str::from_utf8(&buffer).map_err(|_| Error::data("Could not parse string"))?;
+        let s =
+            str::from_utf8(&buffer).map_err(|_| Error::data("string data could not be parsed"))?;
         // We don't support UTF-8
         if !s.is_ascii() {
-            return Err(Error::data("Unsupported string encoding"));
+            return Err(Error::data("non-ASCII string encoding is unsupported"));
         }
 
         visitor.visit_str(s)
@@ -275,10 +276,11 @@ where
 
         self.track_read(buffer.len() + 1)?;
 
-        let s = String::from_utf8(buffer).map_err(|_| Error::data("Could not parse string"))?;
+        let s = String::from_utf8(buffer)
+            .map_err(|_| Error::data("string data could not be parsed"))?;
         // We don't support UTF-8
         if !s.is_ascii() {
-            return Err(Error::data("Unsupported string encoding"));
+            return Err(Error::data("non-ASCII string encoding is unsupported"));
         }
 
         visitor.visit_string(s)

--- a/ultimaonline-net/src/error.rs
+++ b/ultimaonline-net/src/error.rs
@@ -26,10 +26,6 @@ impl de::Error for Error {
 }
 
 impl Error {
-    pub fn io(err: std::io::Error) -> Self {
-        Error::Io(err)
-    }
-
     pub fn data(msg: impl Into<String>) -> Self {
         Error::Data(msg.into())
     }

--- a/ultimaonline-net/src/error.rs
+++ b/ultimaonline-net/src/error.rs
@@ -3,10 +3,15 @@ use std::{fmt, io};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("{0}")]
     Message(String),
+    #[error("serialization failed because {0}")]
+    Serialization(String),
+    #[error("deserialization failed because {0}")]
+    Deserialization(String),
     #[error("{0}")]
     Io(#[from] io::Error),
     #[error("packet data is invalid because {0}")]
@@ -15,18 +20,26 @@ pub enum Error {
 
 impl ser::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        Error::Message(msg.to_string())
+        Error::Serialization(msg.to_string())
     }
 }
 
 impl de::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        Error::Message(msg.to_string())
+        Error::Deserialization(msg.to_string())
     }
 }
 
 impl Error {
     pub fn data(msg: impl Into<String>) -> Self {
         Error::Data(msg.into())
+    }
+
+    pub fn ser(msg: impl Into<String>) -> Self {
+        Error::Serialization(msg.into())
+    }
+
+    pub fn de(msg: impl Into<String>) -> Self {
+        Error::Deserialization(msg.into())
     }
 }

--- a/ultimaonline-net/src/error.rs
+++ b/ultimaonline-net/src/error.rs
@@ -9,7 +9,7 @@ pub enum Error {
     Message(String),
     #[error("{0}")]
     Io(#[from] io::Error),
-    #[error("Invalid data: {0}")]
+    #[error("packet data is invalid because {0}")]
     Data(String),
 }
 

--- a/ultimaonline-net/src/packets/mobile.rs
+++ b/ultimaonline-net/src/packets/mobile.rs
@@ -172,8 +172,6 @@ mod tests {
                 0x00, 0x00, 0x08, 0x8A, 0x8A, 0x8B, 0x8C, 0x8C, 0x00, 0x00, 0x00, 0x00,
             ];
 
-            println!("Packet len: {:x}", input.len());
-
             let parsed = Appearance::from_packet_data(&mut input).expect("Failed to parse packet");
 
             assert_eq!(parsed, appearance);

--- a/ultimaonline-net/src/ser.rs
+++ b/ultimaonline-net/src/ser.rs
@@ -60,19 +60,19 @@ where
     fn serialize_bool(self, v: bool) -> Result<()> {
         self.size += size_of::<bool>();
         if let Some(writer) = &mut self.writer {
-            writer.write_all(&[v as u8][..]).map_err(Error::io)
-        } else {
-            Ok(())
+            writer.write_all(&[v as u8][..])?;
         }
+
+        Ok(())
     }
 
     fn serialize_u8(self, v: u8) -> Result<()> {
         self.size += size_of::<u8>();
         if let Some(writer) = &mut self.writer {
-            writer.write_all(&[v][..]).map_err(Error::io)
-        } else {
-            Ok(())
+            writer.write_all(&[v][..])?;
         }
+
+        Ok(())
     }
 
     fn serialize_i8(self, v: i8) -> Result<()> {
@@ -82,10 +82,10 @@ where
     fn serialize_u16(self, v: u16) -> Result<()> {
         self.size += size_of::<u16>();
         if let Some(writer) = &mut self.writer {
-            writer.write_all(&v.to_be_bytes()).map_err(Error::io)
-        } else {
-            Ok(())
+            writer.write_all(&v.to_be_bytes())?;
         }
+
+        Ok(())
     }
 
     fn serialize_i16(self, v: i16) -> Result<()> {
@@ -95,10 +95,10 @@ where
     fn serialize_u32(self, v: u32) -> Result<()> {
         self.size += size_of::<u32>();
         if let Some(writer) = &mut self.writer {
-            writer.write_all(&v.to_be_bytes()).map_err(Error::io)
-        } else {
-            Ok(())
+            writer.write_all(&v.to_be_bytes())?;
         }
+
+        Ok(())
     }
 
     fn serialize_i32(self, v: i32) -> Result<()> {
@@ -108,10 +108,10 @@ where
     fn serialize_u64(self, v: u64) -> Result<()> {
         self.size += size_of::<u64>();
         if let Some(writer) = &mut self.writer {
-            writer.write_all(&v.to_be_bytes()).map_err(Error::io)
-        } else {
-            Ok(())
+            writer.write_all(&v.to_be_bytes())?;
         }
+
+        Ok(())
     }
 
     fn serialize_i64(self, v: i64) -> Result<()> {
@@ -121,28 +121,28 @@ where
     fn serialize_f32(self, v: f32) -> Result<()> {
         self.size += size_of::<f32>();
         if let Some(writer) = &mut self.writer {
-            writer.write_all(&v.to_be_bytes()).map_err(Error::io)
-        } else {
-            Ok(())
+            writer.write_all(&v.to_be_bytes())?
         }
+
+        Ok(())
     }
 
     fn serialize_f64(self, v: f64) -> Result<()> {
         self.size += size_of::<f64>();
         if let Some(writer) = &mut self.writer {
-            writer.write_all(&v.to_be_bytes()).map_err(Error::io)
-        } else {
-            Ok(())
+            writer.write_all(&v.to_be_bytes())?;
         }
+
+        Ok(())
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<()> {
         self.size += v.len();
         if let Some(writer) = &mut self.writer {
-            writer.write_all(v).map_err(Error::io)
-        } else {
-            Ok(())
+            writer.write_all(v)?;
         }
+
+        Ok(())
     }
 
     fn serialize_char(self, v: char) -> Result<()> {
@@ -153,13 +153,13 @@ where
             let mut buf = [0u8; 1];
             v.encode_utf8(&mut buf);
             if let Some(writer) = &mut self.writer {
-                writer.write_all(&buf).map_err(Error::io)
-            } else {
-                Ok(())
+                writer.write_all(&buf)?;
             }
         } else {
-            Err(Error::data("Unsupported string encoding"))
+            Err(Error::data("Unsupported string encoding"))?;
         }
+
+        Ok(())
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
@@ -168,7 +168,7 @@ where
             self.size += v.len();
 
             if let Some(writer) = &mut self.writer {
-                writer.write_all(v.as_bytes()).map_err(Error::io)?;
+                writer.write_all(v.as_bytes())?;
             }
 
             self.end_null()
@@ -309,10 +309,10 @@ where
     fn end_terminator(&mut self, terminator: &[u8]) -> Result<()> {
         self.size += terminator.len();
         if let Some(writer) = &mut self.writer {
-            writer.write_all(terminator).map_err(Error::io)
-        } else {
-            Ok(())
+            writer.write_all(terminator)?;
         }
+
+        Ok(())
     }
 }
 

--- a/ultimaonline-net/src/ser.rs
+++ b/ultimaonline-net/src/ser.rs
@@ -156,7 +156,7 @@ where
                 writer.write_all(&buf)?;
             }
         } else {
-            Err(Error::data("Unsupported string encoding"))?;
+            Err(Error::data("non-ASCII string encoding is unsupported"))?;
         }
 
         Ok(())
@@ -173,7 +173,7 @@ where
 
             self.end_null()
         } else {
-            Err(Error::data("Unsupported string encoding"))
+            Err(Error::data("non-ASCII string encoding is unsupported"))
         }
     }
 
@@ -191,7 +191,7 @@ where
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
         if let Some(len) = len {
             if len > u16::MAX as usize {
-                return Err(Error::data("Sequence is too long"));
+                return Err(Error::data("sequence is too long"));
             }
         }
 

--- a/uoverse-server/Cargo.toml
+++ b/uoverse-server/Cargo.toml
@@ -16,6 +16,7 @@ uoverse-server-macros = { path = "macros" }
 serde = { version = "1.0.119" }
 erased-serde = "0.3.21"
 ctrlc = "3.2.2"
+eyre = "0.6"
 
 [[bin]]
 name = "login"

--- a/uoverse-server/Cargo.toml
+++ b/uoverse-server/Cargo.toml
@@ -17,6 +17,8 @@ serde = { version = "1.0.119" }
 erased-serde = "0.3.21"
 ctrlc = "3.2.2"
 eyre = "0.6"
+tracing = "0.1"
+tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 
 [[bin]]
 name = "login"

--- a/uoverse-server/macros/src/lib.rs
+++ b/uoverse-server/macros/src/lib.rs
@@ -145,7 +145,7 @@ pub fn define_codec(item: TokenStream) -> TokenStream {
                     match (packet_id, extended_id) {
                         #id_match_arms
                         _ => Err(Self::Error::data(format!(
-                            "Unexpected packet ID: {}",
+                            "packet id {} is unhandled",
                             match extended_id {
                                 Some(ei) => format!("{:#0X}({:#0X})", packet_id, ei),
                                 _ => format!("{:#0X}", packet_id)

--- a/uoverse-server/src/bin/game.rs
+++ b/uoverse-server/src/bin/game.rs
@@ -63,9 +63,7 @@ pub async fn main() {
                 let server = server.clone();
                 tokio::spawn(async move {
                     match preworld(&mut socket).await {
-                        Err(Error::Data(err)) => println!("Client had error in pre-world: {}", err),
-                        Err(Error::Io(err)) => println!("Client had error in pre-world: {}", err),
-                        Err(Error::Message(err)) => println!("Client had error in pre-world: {}", err),
+                        Err(err) => println!("Client had error in pre-world: {}", err),
                         Ok(state) => {
                             println!("Client completed pre-world.");
                             match in_world(server, state).await {
@@ -88,9 +86,7 @@ pub async fn main() {
     }
 
     match server_task.await.expect("Error joining server task") {
-        Err(Error::Message(err)) => println!("Server task had error: {}", err),
-        Err(Error::Io(err)) => println!("Server task had error: {}", err),
-        Err(Error::Data(err)) => println!("Server task had error: {}", err),
+        Err(err) => println!("Server task had error: {}", err),
         Ok(()) => {
             println!("Shutdown complete.");
         }

--- a/uoverse-server/src/bin/login.rs
+++ b/uoverse-server/src/bin/login.rs
@@ -52,9 +52,7 @@ pub async fn main() {
         let (mut socket, _) = listener.accept().await.unwrap();
         tokio::spawn(async move {
             match process(&mut socket, game_socket).await {
-                Err(Error::Data(err)) => println!("Client had error: {}", err),
-                Err(Error::Io(err)) => println!("Client had error: {}", err),
-                Err(Error::Message(err)) => println!("Client had error: {}", err),
+                Err(err) => println!("Client had error: {}", err),
                 Ok(()) => {
                     println!("Client disconnected.");
                     socket.shutdown().await.unwrap();

--- a/uoverse-server/src/game/server.rs
+++ b/uoverse-server/src/game/server.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashSet,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
+        Mutex,
     },
 };
 use tokio::sync::mpsc;
@@ -22,7 +22,7 @@ struct World {
 }
 
 pub struct Server {
-    shutdown: Arc<AtomicBool>,
+    shutdown: AtomicBool,
     clients: Mutex<Vec<WorldClient>>,
     world: Mutex<World>,
 }
@@ -30,9 +30,9 @@ pub struct Server {
 const PLAYER_SERIAL: Serial = 3833;
 
 impl Server {
-    pub fn new(shutdown: Arc<AtomicBool>) -> Self {
+    pub fn new() -> Self {
         Server {
-            shutdown,
+            shutdown: AtomicBool::new(false),
             clients: Mutex::new(vec![]),
             world: Mutex::new(World {
                 mob_x: 3668,
@@ -240,5 +240,9 @@ impl Server {
         )?;
 
         Ok(())
+    }
+
+    pub fn shutdown(&self) {
+        self.shutdown.store(true, Ordering::Relaxed)
     }
 }

--- a/uoverse-server/src/game/server.rs
+++ b/uoverse-server/src/game/server.rs
@@ -6,6 +6,7 @@ use std::{
     },
 };
 use tokio::sync::mpsc;
+use tracing::{debug, info, trace_span, trace};
 use ultimaonline_net::{
     error::{Error, Result},
     packets::movement,
@@ -44,10 +45,13 @@ impl Server {
     pub async fn run_loop(&self) -> Result<()> {
         use ultimaonline_net::{packets::mobile, types};
 
+        let span = trace_span!("server");
+        let _ = span.enter();
+
         let mut frame = 0;
         while !self.shutdown.load(Ordering::Relaxed) {
             frame += 1;
-            println!("Frame: {}", frame);
+            trace!("Frame: {}", frame);
             {
                 // Update world state
                 let mut world = self
@@ -142,7 +146,7 @@ impl Server {
             client.close();
         }
 
-        println!("Server shutting down.");
+        info!("Server shutting down.");
         Ok(())
     }
 
@@ -158,7 +162,7 @@ impl Server {
         };
 
         self.enter_world(&mut client)?;
-        println!("Client completed enter world.");
+        debug!("Client completed enter world.");
 
         self.clients
             .lock()


### PR DESCRIPTION
This starts the process of using a more production-ready design by improving the error handling with `thiserror` and `eyre`, as well as the logging with `tracing`.