### PR TITLE
Support sending extended packets

### DIFF
--- a/ultimaonline-net/macros/src/lib.rs
+++ b/ultimaonline-net/macros/src/lib.rs
@@ -116,6 +116,10 @@ fn packet_from_content(content_type: &Type, args: &PacketArgs) -> proc_macro2::T
     };
 
     quote! {
+        impl#impl_param crate::packets::IntoPacket for #from_type {
+            type Content = #content_type;
+        }
+
         impl#impl_param ::std::convert::From<#from_type> for crate::packets::Packet<#content_type> {
             fn from(val: #from_type) -> Self {
                 #size_calc

--- a/ultimaonline-net/src/packets.rs
+++ b/ultimaonline-net/src/packets.rs
@@ -41,11 +41,12 @@ where
     fn from_packet_data<R: BufRead>(reader: &mut R) -> Result<Self>;
 }
 
-pub fn write_packet<T, W: Write>(content: T, dst: &mut W) -> Result<()>
+pub fn write_packet<T, U, W: Write>(content: T, dst: &mut W) -> Result<()>
 where
     T: Serialize,
-    Packet<T>: From<T>,
+    U: Serialize,
+    Packet<U>: From<T>,
 {
-    Packet::<T>::from(content).to_writer(dst)?;
+    Packet::<U>::from(content).to_writer(dst)?;
     Ok(())
 }

--- a/ultimaonline-net/src/packets.rs
+++ b/ultimaonline-net/src/packets.rs
@@ -34,6 +34,10 @@ where
     }
 }
 
+pub trait IntoPacket {
+    type Content;
+}
+
 pub trait FromPacketData
 where
     Self: Sized,

--- a/uoverse-server/macros/src/lib.rs
+++ b/uoverse-server/macros/src/lib.rs
@@ -210,16 +210,19 @@ pub fn define_codec(item: TokenStream) -> TokenStream {
         quote! {
             #vis trait #trait_name {}
 
-            #( impl #trait_name for #pkts {} )*
+            #(
+                impl #trait_name for #pkts {}
+                impl #trait_name for &#pkts {}
+            )*
 
-            impl<'a, P> ::tokio_util::codec::Encoder<&'a P> for #codec_name
+            impl<P> ::tokio_util::codec::Encoder<P> for #codec_name
             where
                 P: #trait_name + ::serde::ser::Serialize,
-                ::ultimaonline_net::packets::Packet<&'a P>: ::std::convert::From<&'a P>,
+                ::ultimaonline_net::packets::Packet<P>: ::std::convert::From<P>,
             {
                 type Error = ::ultimaonline_net::error::Error;
 
-                fn encode(&mut self, pkt: &'a P, dst: &mut ::bytes::BytesMut) -> Result<(), Self::Error> {
+                fn encode(&mut self, pkt: P, dst: &mut ::bytes::BytesMut) -> Result<(), Self::Error> {
                     use ::bytes::BufMut;
 
                     ::ultimaonline_net::packets::write_packet(pkt, &mut dst.writer())

--- a/uoverse-server/macros/src/lib.rs
+++ b/uoverse-server/macros/src/lib.rs
@@ -215,10 +215,11 @@ pub fn define_codec(item: TokenStream) -> TokenStream {
                 impl #trait_name for &#pkts {}
             )*
 
-            impl<P> ::tokio_util::codec::Encoder<P> for #codec_name
+            impl<P, Q> ::tokio_util::codec::Encoder<P> for #codec_name
             where
-                P: #trait_name + ::serde::ser::Serialize,
-                ::ultimaonline_net::packets::Packet<P>: ::std::convert::From<P>,
+                P: #trait_name<Content = Q> + ::serde::ser::Serialize,
+                Q: ::serde::ser::Serialize,
+                ::ultimaonline_net::packets::Packet<Q>: ::std::convert::From<P>,
             {
                 type Error = ::ultimaonline_net::error::Error;
 

--- a/uoverse-server/macros/src/lib.rs
+++ b/uoverse-server/macros/src/lib.rs
@@ -208,7 +208,7 @@ pub fn define_codec(item: TokenStream) -> TokenStream {
 
         let pkts = codec_def.send_pkts.iter();
         quote! {
-            #vis trait #trait_name {}
+            #vis trait #trait_name: ::ultimaonline_net::packets::IntoPacket {}
 
             #(
                 impl #trait_name for #pkts {}

--- a/uoverse-server/src/game/client.rs
+++ b/uoverse-server/src/game/client.rs
@@ -42,10 +42,10 @@ pub struct CharList<Io: AsyncIo> {
 }
 
 impl<Io: AsyncIo> CharList<Io> {
-    pub async fn send<'a, P>(&mut self, pkt: &'a P) -> Result<()>
+    pub async fn send<P>(&mut self, pkt: P) -> Result<()>
     where
         P: codecs::CharListPacketSend + ::serde::ser::Serialize,
-        Packet<&'a P>: From<&'a P>,
+        Packet<P>: From<P>,
     {
         self.framer.send(pkt).await
     }
@@ -108,10 +108,10 @@ pub struct CharLogin<Io: AsyncIo> {
 }
 
 impl<Io: AsyncIo> CharLogin<Io> {
-    pub async fn send<'a, P>(&mut self, pkt: &'a P) -> Result<()>
+    pub async fn send<P>(&mut self, pkt: P) -> Result<()>
     where
         P: codecs::CharLoginPacketSend + ::serde::ser::Serialize,
-        Packet<&'a P>: From<&'a P>,
+        Packet<P>: From<P>,
     {
         self.framer.send(pkt).await
     }
@@ -135,10 +135,10 @@ pub struct InWorld<Io: AsyncIo> {
 }
 
 impl<Io: AsyncIo> InWorld<Io> {
-    pub async fn send<'a, P>(&mut self, pkt: &'a P) -> Result<()>
+    pub async fn send<P>(&mut self, pkt: P) -> Result<()>
     where
         P: codecs::InWorldPacketSend + ::serde::ser::Serialize,
-        Packet<&'a P>: From<&'a P>,
+        Packet<P>: From<P>,
     {
         self.framer.send(pkt).await
     }

--- a/uoverse-server/src/game/client.rs
+++ b/uoverse-server/src/game/client.rs
@@ -42,10 +42,11 @@ pub struct CharList<Io: AsyncIo> {
 }
 
 impl<Io: AsyncIo> CharList<Io> {
-    pub async fn send<P>(&mut self, pkt: P) -> Result<()>
+    pub async fn send<P, Q>(&mut self, pkt: P) -> Result<()>
     where
-        P: codecs::CharListPacketSend + ::serde::ser::Serialize,
-        Packet<P>: From<P>,
+        P: codecs::CharListPacketSend<Content = Q> + ::serde::ser::Serialize,
+        Q: ::serde::ser::Serialize,
+        Packet<Q>: From<P>,
     {
         self.framer.send(pkt).await
     }
@@ -108,10 +109,11 @@ pub struct CharLogin<Io: AsyncIo> {
 }
 
 impl<Io: AsyncIo> CharLogin<Io> {
-    pub async fn send<P>(&mut self, pkt: P) -> Result<()>
+    pub async fn send<P, Q>(&mut self, pkt: P) -> Result<()>
     where
-        P: codecs::CharLoginPacketSend + ::serde::ser::Serialize,
-        Packet<P>: From<P>,
+        P: codecs::CharLoginPacketSend<Content = Q> + ::serde::ser::Serialize,
+        Q: ::serde::ser::Serialize,
+        Packet<Q>: From<P>,
     {
         self.framer.send(pkt).await
     }
@@ -135,10 +137,11 @@ pub struct InWorld<Io: AsyncIo> {
 }
 
 impl<Io: AsyncIo> InWorld<Io> {
-    pub async fn send<P>(&mut self, pkt: P) -> Result<()>
+    pub async fn send<P, Q>(&mut self, pkt: P) -> Result<()>
     where
-        P: codecs::InWorldPacketSend + ::serde::ser::Serialize,
-        Packet<P>: From<P>,
+        P: codecs::InWorldPacketSend<Content = Q> + ::serde::ser::Serialize,
+        Q: ::serde::ser::Serialize,
+        Packet<Q>: From<P>,
     {
         self.framer.send(pkt).await
     }

--- a/uoverse-server/src/game/client/codecs.rs
+++ b/uoverse-server/src/game/client/codecs.rs
@@ -87,15 +87,15 @@ impl<C> CompressionCodec<C> {
     }
 }
 
-impl<'a, I, C: Encoder<&'a I>> Encoder<&'a I> for CompressionCodec<C> {
+impl<I, C: Encoder<I>> Encoder<I> for CompressionCodec<C> {
     type Error = C::Error;
 
-    fn encode(&mut self, pkt: &'a I, dst: &mut BytesMut) -> std::result::Result<(), Self::Error> {
+    fn encode(&mut self, pkt: I, dst: &mut BytesMut) -> std::result::Result<(), Self::Error> {
         use bytes::BufMut;
         use ultimaonline_net::compression::huffman;
 
         let mut tmp = BytesMut::with_capacity(64);
-        self.codec.encode(&pkt, &mut tmp)?;
+        self.codec.encode(pkt, &mut tmp)?;
         let compressed = huffman::compress(&*tmp);
 
         dst.put(compressed.as_slice());

--- a/uoverse-server/src/login/client.rs
+++ b/uoverse-server/src/login/client.rs
@@ -53,10 +53,11 @@ pub struct Login<Io: AsyncIo> {
 }
 
 impl<Io: AsyncIo> Login<Io> {
-    pub async fn send<P>(&mut self, pkt: P) -> Result<()>
+    pub async fn send<P, Q>(&mut self, pkt: P) -> Result<()>
     where
-        P: codecs::LoginPacketSend + ::serde::ser::Serialize,
-        Packet<P>: From<P>,
+        P: codecs::LoginPacketSend<Content = Q> + ::serde::ser::Serialize,
+        Q: ::serde::ser::Serialize,
+        Packet<Q>: From<P>,
     {
         self.framer.send(pkt).await
     }
@@ -98,10 +99,11 @@ pub struct Handoff<Io: AsyncIo> {
 }
 
 impl<Io: AsyncIo> Handoff<Io> {
-    pub async fn send<P>(&mut self, pkt: P) -> Result<()>
+    pub async fn send<P, Q>(&mut self, pkt: P) -> Result<()>
     where
-        P: codecs::HandoffPacketSend + ::serde::ser::Serialize,
-        Packet<P>: From<P>,
+        P: codecs::HandoffPacketSend<Content = Q> + ::serde::ser::Serialize,
+        Q: ::serde::ser::Serialize,
+        Packet<Q>: From<P>,
     {
         self.framer.send(pkt).await
     }

--- a/uoverse-server/src/login/client.rs
+++ b/uoverse-server/src/login/client.rs
@@ -53,10 +53,10 @@ pub struct Login<Io: AsyncIo> {
 }
 
 impl<Io: AsyncIo> Login<Io> {
-    pub async fn send<'a, P>(&mut self, pkt: &'a P) -> Result<()>
+    pub async fn send<P>(&mut self, pkt: P) -> Result<()>
     where
         P: codecs::LoginPacketSend + ::serde::ser::Serialize,
-        Packet<&'a P>: From<&'a P>,
+        Packet<P>: From<P>,
     {
         self.framer.send(pkt).await
     }
@@ -98,10 +98,10 @@ pub struct Handoff<Io: AsyncIo> {
 }
 
 impl<Io: AsyncIo> Handoff<Io> {
-    pub async fn send<'a, P>(&mut self, pkt: &'a P) -> Result<()>
+    pub async fn send<P>(&mut self, pkt: P) -> Result<()>
     where
         P: codecs::HandoffPacketSend + ::serde::ser::Serialize,
-        Packet<&'a P>: From<&'a P>,
+        Packet<P>: From<P>,
     {
         self.framer.send(pkt).await
     }


### PR DESCRIPTION
Support for receiving extended packets was added in #2 but that PR did not include support for sending them, as we did not have any need yet.

Now that I'm testing custom map stuff, it is useful to be able to send a map change packet, which is an extended packet. This PR updates the `packet` macro in `ultimaonline-net` and the `codec` macro in `uoverse-server` to allow for that, and somewhat improves that code generally by having more flexible trait implementations.